### PR TITLE
Use Gtk.Application instead of deprecated Granite.Application

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,7 +21,7 @@
 
 namespace monilet {
 
-    public class Monilet : Granite.Application {
+    public class Monilet : Gtk.Application {
 
         // Main Window
         private MainWindow? app_window = null;
@@ -31,11 +31,6 @@ namespace monilet {
             //Base
             Object (application_id: "com.github.kmal-kenneth.monilet",
             flags: ApplicationFlags.FLAGS_NONE);
-            
-            //Config app
-            program_name = "Monilet";
-            Granite.Services.Logger.initialize (this.program_name);
-            Granite.Services.Logger.DisplayLevel = Granite.Services.LogLevel.DEBUG;
         }
         
         //Active App


### PR DESCRIPTION
[Granite.Application is deprecated](https://github.com/elementary/granite/blob/3c25b6c95e5ddf3fcc3bdf8bf1014f6d2246e677/lib/Application.vala#L25) since 0.5.0 and should not be used anymore.
